### PR TITLE
Create initial storage brokering structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ config.yml
 # development productivity files 
 TODO.md
 
+# ide config files
+.vscode/*
+.idea/*
+
 # auto-gen files
 __pycache__/
 
@@ -11,9 +15,9 @@ __pycache__/
 *.egg-info/
 *.egg
 
-# test files
-test_*
-test*
+## test files
+#test_*
+#test*
 
 # build or python virtual env files
 /venv

--- a/fGOaria/__init__.py
+++ b/fGOaria/__init__.py
@@ -1,7 +1,9 @@
+# Export externally-available functionality here
 from .classes.bucket import Bucket
-from .classes.aria_client import AriaClient
+from .classes.aria_manager import ARIA as ARIA, ARIA as AriaClient
 from .classes.field import Field
 from .classes.record import Record
+from .classes.storage_manager import StorageManager
 from .classes.technical_review import TechEvaluation
 from .utils.utility_functions import *
 from .utils.imports_config import *

--- a/fGOaria/classes/api_client.py
+++ b/fGOaria/classes/api_client.py
@@ -1,18 +1,27 @@
+from abc import ABC, abstractmethod
 from ..utils.imports_config import *
-from ..utils.utility_functions import set_headers, get_config
-from dotenv import load_dotenv
 
-load_dotenv()
-class APIClient:
+
+class APIClient(ABC):
+    """
+    Generic API client class
+    """
+
     def __init__(self, token):
         self.token = token
-        self.dev = os.getenv('DEV', 'LOCAL')
-        if self.dev == 'LOCAL':
-            self.aria_login_url = os.getenv('ARIA_CONNECTION_LOGIN_URL_LOCAL')
-        else: 
-            self.aria_login_url = os.getenv('ARIA_CONNECTION_LOGIN_URL')
-        self.headers = set_headers(self.token) if self.token else None
-        self.base_url = os.getenv(f'ARIA_GQL_{self.dev}')
+
+    @property
+    @abstractmethod
+    def base_url(self) -> str:
+        pass
+
+    @property
+    def headers(self) -> dict:
+        return self.headers
+
+    @headers.setter
+    def headers(self, value):
+        self.headers = {'Authorization': f'Bearer {self.token}'} if self.token else None
 
     def get(self, endpoint, params=None):
         url = f"{self.base_url}/{endpoint}"
@@ -23,11 +32,10 @@ class APIClient:
         resp.raise_for_status()
         return resp.json()
 
-    def post(self, endpoint : str, data : dict = None):
+    def post(self, endpoint: str, data: dict = None):
         resp = requests.post(endpoint, json=data, headers=self.headers)
         resp.raise_for_status()
         return resp.json()
-    
 
     def gql_query(self, query: str, variables: dict = None):
         """GraphQL POST request."""

--- a/fGOaria/classes/aria_client.py
+++ b/fGOaria/classes/aria_client.py
@@ -1,51 +1,27 @@
-from .oauth import OAuth
-from .data_manager import DataManager
-from .cli_techeval import TechEvalCLI
-from .data_manager import DataManager
-from .cli_data_manager import DataManagerCLI
-from .token import Token
-class AriaClient :
-    '''
-    Super class. New instances initiated in the `commands`. All functionality will start with one of these methods.
-    '''
+from abc import ABC
+from fGOaria.classes.api_client import APIClient
+from fGOaria.utils.imports_config import *
+from dotenv import load_dotenv
 
-    def __init__(self, login=False,):
-        self.oauth = OAuth()
-        if not login:
-            self._fetch_token()
-        
+load_dotenv()
+
+class AriaClient(APIClient, ABC):
+    """
+    Abstract client to interface with ARIA's APIs, extend for specific APIs such as access/data mgmt, etc
+    """
+
+    def __init__(self, token):
+        super().__init__(token)
+        self.dev = os.getenv('DEV', 'LOCAL')
+        if self.dev == 'LOCAL':
+            self.aria_login_url = os.getenv('ARIA_CONNECTION_LOGIN_URL_LOCAL')
+        else: 
+            self.aria_login_url = os.getenv('ARIA_CONNECTION_LOGIN_URL')
+
     @property
-    def token(self):
-        if not self._token:
-            self._fetch_token()
-        return self._token
-        
-    def login(self, username = None, password = None):
-        self.oauth.login(username, password)
-        self._fetch_token()
+    def base_url(self) -> str:
+        return self.base_url
 
-    def new_data_manager(self, id, type, populate=False):
-        return (DataManager(self.token, id, type, populate))
-    
-    def new_cli_manager(self, id, type, populate=False) :
-        return (DataManagerCLI(self.token, id, type, populate))
-    
-    
-    def new_cli_tech_eval(self) :
-        return (TechEvalCLI(self.token))
-
-    def new_data_managers(self, entities=None):
-        if entities is None:
-            entities = {}
-
-        data_managers = {}
-        for key, value in entities.items():
-            data_managers[f'data_manager_{key}_{value}'] = DataManager(self.token, key, value, True)
-        return data_managers
-    
-    def get_access_token(self):
-        return self.oauth.get_access_token()
-
-    def _fetch_token(self):
-        token : Token = self.get_access_token()
-        self._token = token.access_token
+    @base_url.setter
+    def base_url(self, value):
+        self.base_url = os.getenv(f'ARIA_GQL_{self.dev}')

--- a/fGOaria/classes/aria_manager.py
+++ b/fGOaria/classes/aria_manager.py
@@ -1,0 +1,52 @@
+from fGOaria.classes.oauth import OAuth
+from fGOaria.classes.data_manager import DataManager
+from fGOaria.classes.cli_techeval import TechEvalCLI
+from fGOaria.classes.cli_data_manager import DataManagerCLI
+from fGOaria.classes.token import Token
+
+class ARIA:
+    """
+    Main interface for ARIA APIs
+    @deprecated Matter of opinion, but I don't see what purpose this serves other than as another layer of abstraction
+    """
+
+    def __init__(self, login=False,):
+        self.oauth = OAuth()
+        if not login:
+            self._fetch_token()
+        
+    @property
+    def token(self):
+        if not self._token:
+            self._fetch_token()
+        return self._token
+        
+    def login(self, username = None, password = None):
+        self.oauth.login(username, password)
+        self._fetch_token()
+
+    def new_data_manager(self, id, type, populate=False):
+        return (DataManager(self.token, id, type, populate))
+    
+    def new_cli_manager(self, id, type, populate=False) :
+        return (DataManagerCLI(self.token, id, type, populate))
+    
+    
+    def new_cli_tech_eval(self) :
+        return (TechEvalCLI(self.token))
+
+    def new_data_managers(self, entities=None):
+        if entities is None:
+            entities = {}
+
+        data_managers = {}
+        for key, value in entities.items():
+            data_managers[f'data_manager_{key}_{value}'] = DataManager(self.token, key, value, True)
+        return data_managers
+    
+    def get_access_token(self):
+        return self.oauth.get_access_token()
+
+    def _fetch_token(self):
+        token : Token = self.get_access_token()
+        self._token = token.access_token

--- a/fGOaria/classes/client_data_manager.py
+++ b/fGOaria/classes/client_data_manager.py
@@ -1,17 +1,18 @@
-import os
-import json
 from typing import Union, Dict, Any
-from .field import Field
-from .bucket import Bucket
-from .record import Record
-from .api_client import APIClient
-from ..utils.imports_config import *
-from .queries import CREATE_DATA_BUCKET, CREATE_DATA_RECORD, CREATE_DATA_FIELD, BUCKET_ITEMS, RECORD_ITEMS, FIELD_ITEMS
 from dotenv import load_dotenv
+from fGOaria.classes.field import Field
+from fGOaria.classes.bucket import Bucket
+from fGOaria.classes.record import Record
+from fGOaria.classes.aria_client import AriaClient
+from fGOaria.utils.imports_config import *
+from fGOaria.utils.queries import (
+    CREATE_DATA_BUCKET, CREATE_DATA_RECORD, CREATE_DATA_FIELD,
+    BUCKET_ITEMS, RECORD_ITEMS, FIELD_ITEMS
+)
 
 load_dotenv()
 
-class DataManagerClient(APIClient):
+class DataManagerClient(AriaClient):
     def __init__(self, token: str, entity_id: int, entity_type: str):
         super().__init__(token)
         self.id = entity_id

--- a/fGOaria/classes/client_oauth.py
+++ b/fGOaria/classes/client_oauth.py
@@ -1,7 +1,7 @@
-from .api_client import APIClient
+from .aria_client import AriaClient
 from ..utils.imports_config import *
 
-class ClientOauth(APIClient) :
+class AriaOauthClient(AriaClient) :
 
     def __init__(self, token=None):
         super().__init__(token)

--- a/fGOaria/classes/client_provider.py
+++ b/fGOaria/classes/client_provider.py
@@ -1,0 +1,84 @@
+from .api_client import APIClient
+from .token import Token
+from .storage_provider import StorageProvider
+from abc import ABC, abstractmethod
+
+class ProviderClient(APIClient, ABC):
+    """
+    Abstract storage provider client class. Clients for external storage providers should inherit from this class.
+    """
+
+    def __init__(self, provider: StorageProvider):
+        self._provider = provider
+        super().__init__(self._token.access_token)
+
+    @property
+    def _token(self) -> Token:
+        return Token(self._provider.credentials)
+
+    @property
+    def file_id(self) -> str:
+        return self._file_id
+
+    @file_id.setter
+    def file_id(self, file_id: str):
+        self._file_id = file_id
+
+    @abstractmethod
+    def locate(self, file_id) -> object:
+        """Get the location details of the file"""
+        pass
+
+    @abstractmethod
+    def upload(self, file_location) -> object:
+        """Push file to external storage provider"""
+        pass
+
+    @abstractmethod
+    def download(self, file_id) -> object:
+        """Download file from external storage provider"""
+        pass
+
+    @abstractmethod
+    def delete(self, file_id) -> object:
+        """Delete file from external storage provider"""
+        pass
+
+
+class OneDataClient(ProviderClient):
+    """
+    Provider client for OneData
+    """
+
+    def __init__(self, provider: StorageProvider):
+        super().__init__(provider)
+        self.provider_host = provider.credentials.get('host_endpoint')
+        self.space_id = provider.credentials.get('space_id')
+
+    @property
+    def base_url(self) -> str:
+        return f"{self.provider_host}/api/v3/oneprovider/data/{self.space_id}/"
+
+    def locate(self, file_id) -> object:
+        """@todo find the location of the file on OneData"""
+        pass
+
+    def upload(self, filename) -> object:
+        """@todo get this working"""
+        self.headers['Content-Type'] = 'application/octet-stream'
+        endpoint = f"{self.base_url}children?name={filename}&override=true"
+        with open(filename, 'rb') as file:
+            response = self.post(endpoint, {'file': file})
+        print(f"Push: {response.status_code} - {response.text}")
+        # TODO: handle bad status codes
+        if response.status_code in range(200, 300):
+            self.file_id = response.file_id
+        return response
+
+    def download(self, file_id) -> object:
+        """@todo """
+        pass
+
+    def delete(self, file_id) -> object:
+        """@todo"""
+        pass

--- a/fGOaria/classes/client_review.py
+++ b/fGOaria/classes/client_review.py
@@ -1,11 +1,10 @@
-from ..utils.imports_config import *
-from .api_client import APIClient
 from dotenv import load_dotenv
-from .queries import PULL_VISITS, TECHNICAL_REVIEW_FIELDS, SAVE_TECH_EVAL
+from fGOaria.classes.aria_client import AriaClient
+from fGOaria.utils.queries import PULL_VISITS, TECHNICAL_REVIEW_FIELDS, SAVE_TECH_EVAL
 
 load_dotenv()
 
-class ReviewClient(APIClient):
+class ReviewClient(AriaClient):
     def __init__(self, token):
         super().__init__(token)
 

--- a/fGOaria/classes/client_storage.py
+++ b/fGOaria/classes/client_storage.py
@@ -1,0 +1,56 @@
+import os
+from dotenv import load_dotenv
+from typing import Dict
+from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.storage_provider import StorageProvider
+from fGOaria.classes.token import Token
+# from fGOaria.utils.queries import GET_STORAGE_PROVIDERS, FETCH_STORAGE_TOKENS, CHECK_STORAGE_VALIDITY
+
+
+load_dotenv()
+
+class StorageClient(AriaClient):
+    """
+    APIClient for ARIA's storage manager API
+    @todo currently a stub, still to be hooked up to actual API
+    """
+
+    def __init__(self, token, entity_id: str, entity_type: str):
+        super().__init__(token)
+        self.id = entity_id
+        self.type = entity_type
+
+    def get_provider_options(self) -> Dict[str, StorageProvider]:
+        """
+        Retrieve all available storage provider options
+        @todo use ARIA storageProviders query
+        """
+        print(f'Getting provider options for {self.type} ID {self.id}')
+        return {'OneDataClient': StorageProvider(
+            provider_id='1',
+            name="OneData",
+            description="High-performance data management solution",
+            credentials={
+                'host_endpoint': os.getenv("ONEDATA_HOST_ENDPOINT"),
+                'token': self.get_provider_token('1'),
+                'space_id': os.getenv("ONEDATA_SPACE_ID"),
+            }
+        )}
+
+    def get_provider_token(self, provider_id: str) -> Token or None:
+        """
+        Retrieve the token for a specific provider
+        @todo use ARIA getStorageTokens mutation
+        """
+        print(f'Pulling token')
+        return Token({
+            'access_token': os.getenv("ONEDATA_ACCESS_TOKEN"),
+            'expires_in': None,
+            'refresh_expires_in': None,
+            'refresh_token': None,
+            'token_type': None,
+            'not-before-policy': None,
+            'session_state': None,
+            'scope': None,
+            'timestamp': None,
+        }) if provider_id == '1' else None

--- a/fGOaria/classes/oauth.py
+++ b/fGOaria/classes/oauth.py
@@ -1,5 +1,5 @@
 from ..utils.utility_functions import get_formatted_datetime, print_with_spaces, check_headers, space
-from .client_oauth import ClientOauth
+from .client_oauth import AriaOauthClient
 from ..utils.imports_config import *
 from .token import Token
 from ..utils.encryption import TokenEncryption
@@ -8,7 +8,7 @@ from pathlib import Path
 
 class OAuth :
     def __init__(self) -> None:
-        self.client = ClientOauth()
+        self.client = AriaOauthClient()
         self.username = os.getenv('ARIA_CONNECTION_USERNAME')
         self.password = os.getenv('ARIA_CONNECTION_PASSWORD')
         self.grant_type = os.getenv('ARIA_CONNECTION_GRANT_TYPE')

--- a/fGOaria/classes/storage_manager.py
+++ b/fGOaria/classes/storage_manager.py
@@ -1,0 +1,38 @@
+from fGOaria.classes.client_storage import StorageClient
+from fGOaria.classes.client_provider import *
+from fGOaria.classes import client_provider
+from fGOaria.classes.storage_provider import StorageProvider
+
+class StorageManager:
+    """
+    Manages available storage options for a given ARIA Entity ID
+    """
+
+    def __init__(self, aria_token: None, entity_id: str, entity_type: str):
+        self._storage_client = StorageClient(aria_token, entity_id, entity_type)
+
+    @property
+    def providers(self) -> dict[str, StorageProvider]:
+        """Get the available storage providers"""
+        return self._storage_client.get_provider_options()
+
+    @property
+    def selected(self) -> StorageProvider:
+        return self._selected
+
+    @selected.setter
+    def selected(self, provider: StorageProvider):
+        self._selected = provider
+
+    def select(self, client_option: str) -> ProviderClient:
+        """Select a provider"""
+
+        if (self.providers.get(client_option) is None):
+            Exception(f"No provider option with id {client_option}")
+
+        self._selected = self.providers.get(client_option)
+
+        client = getattr(client_provider, client_option)
+        self._client = client(self._selected)
+
+        return self._client

--- a/fGOaria/classes/storage_provider.py
+++ b/fGOaria/classes/storage_provider.py
@@ -1,0 +1,46 @@
+class StorageProvider():
+    def __init__(self, provider_id: str, name: str, description: str, credentials: dict):
+        self._id = provider_id
+        self._name = name
+        self._description = description
+        self._credentials = credentials
+
+    @property
+    def provider_id(self) -> str:
+        """Getter for the Provider ID."""
+        return self._provider_id
+
+    @provider_id.setter
+    def provider_id(self, value):
+        """Setter for the Provider ID."""
+        self._provider_id = value
+
+    @property
+    def name(self) -> str:
+        """Getter for the name of the provider."""
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        """Setter for the name of the provider."""
+        self._name = value
+
+    @property
+    def description(self) -> str:
+        """Getter for the description of the provider."""
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        """Setter for the description of the provider."""
+        self._description = value
+
+    @property
+    def credentials(self) -> dict:
+        """Get credentials from my provider."""
+        return self._credentials
+
+    @credentials.setter
+    def credentials(self, value):
+        """Setter for the description of the provider."""
+        self._credentials = value

--- a/fGOaria/classes/token.py
+++ b/fGOaria/classes/token.py
@@ -1,4 +1,4 @@
-from ..utils.imports_config import datetime, timedelta
+from fGOaria.utils.imports_config import datetime, timedelta
 
 class Token:
     def __init__(self, token_data):

--- a/fGOaria/commands/create_bucket.py
+++ b/fGOaria/commands/create_bucket.py
@@ -1,11 +1,11 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 @click.command()
 def create_bucket():
     """Create a new Bucket for a Visit or Proposal"""
-    cli = AriaClient()
+    cli = ARIA()
     entity_details = get_entity()
     manager = cli.new_cli_manager(entity_details['id'],entity_details['type'],True)
     manager.create_bucket_cli()

--- a/fGOaria/commands/create_field.py
+++ b/fGOaria/commands/create_field.py
@@ -1,13 +1,13 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 
 @click.command()
 def create_field():
     """Create a new Fieldd for a Visit or Proposal"""
 
-    cli = AriaClient()
+    cli = ARIA()
     entity_details = get_entity()
     manager = cli.new_cli_manager(entity_details.get('id'),entity_details.get('type'),True)
     manager.create_field_cli()

--- a/fGOaria/commands/create_record.py
+++ b/fGOaria/commands/create_record.py
@@ -1,12 +1,12 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 @click.command()
 def create_record():
     """Create a new Record for a Visit or Proposal"""
 
-    cli = AriaClient()
+    cli = ARIA()
     entity_details = get_entity()
     manager = cli.new_cli_manager(entity_details.get('id'),entity_details.get('type'),True)
     manager.create_record_cli()

--- a/fGOaria/commands/list_buckets.py
+++ b/fGOaria/commands/list_buckets.py
@@ -1,12 +1,12 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 @click.command()
 def list_buckets():
     """Display buckets associated with a Visit or Proposal"""
 
-    cli = AriaClient()
+    cli = ARIA()
     entity_details = get_entity()
     manager = cli.new_cli_manager(entity_details.get('id'),entity_details.get('type'),True)
     manager.printer_cli('Bucket')

--- a/fGOaria/commands/list_fields.py
+++ b/fGOaria/commands/list_fields.py
@@ -1,12 +1,12 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 @click.command()
 def list_fields():
     """Display records associated with a Visit or Proposal"""
 
-    cli = AriaClient()
+    cli = ARIA()
     entity_details = get_entity()
     manager = cli.new_cli_manager(entity_details.get('id'),entity_details.get('type'),True)
     manager.printer_cli('Field')

--- a/fGOaria/commands/list_records.py
+++ b/fGOaria/commands/list_records.py
@@ -1,11 +1,11 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 @click.command()
 def list_records():
     """Display fields associated with a Visit or Proposal"""
-    cli = AriaClient()
+    cli = ARIA()
     entity_details = get_entity()
     manager = cli.new_cli_manager(entity_details.get('id'),entity_details.get('type'),True)
     manager.printer_cli('Record')

--- a/fGOaria/commands/login.py
+++ b/fGOaria/commands/login.py
@@ -1,6 +1,6 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click, os
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -20,8 +20,8 @@ def login(username, password):
     """Login to ARIA and retrieve a token. Store in keyring."""
 
     if password_default_prompt == password :
-        aria_cli = AriaClient(True)
+        aria_cli = ARIA(True)
         aria_cli.login(username, password_default)
     else :
-        aria_cli = AriaClient(True)
+        aria_cli = ARIA(True)
         aria_cli.login(username, password)

--- a/fGOaria/commands/tech_eval.py
+++ b/fGOaria/commands/tech_eval.py
@@ -1,12 +1,12 @@
 from fGOaria.utils.utility_functions import get_entity
 from fGOaria.utils.imports_config import click
-from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.aria_manager import ARIA
 
 
 @click.command()
 def tech_eval():
     """Retrieve & Submit Technical Review for a Visit"""
 
-    cli = AriaClient()
+    cli = ARIA()
     tech = cli.new_cli_tech_eval()
     tech.menu()

--- a/fGOaria/utils/queries.py
+++ b/fGOaria/utils/queries.py
@@ -134,3 +134,19 @@ SAVE_TECH_EVAL =  """
     }
     """
 
+# TODO: separate queries and mutations
+# TODO: use graphQL queries/mutations
+# GET_STORAGE_PROVIDERS - GQLQuery(
+#     query = """""",
+#     return_key = "storageProviderItems"
+# )
+#
+# FETCH_STORAGE_TOKENS = GQLMutation(
+#     mutation = """""",
+#     return_key = "storageTokenItems"
+# )
+#
+# CHECK_STORAGE_VALIDITY = GQLMutation(
+#     mutation = """""",
+#     return_key = "storageTokenItems"
+# )

--- a/fGOaria/utils/utility_functions.py
+++ b/fGOaria/utils/utility_functions.py
@@ -39,11 +39,6 @@ def check_headers(json):
             return False
     return True
 
-def set_headers(token) :
-    """Return a variable that holds a token to be used in a request"""
-    return  {'Authorization': f'Bearer {token}'}
-
-
 
 # CONFIG
 

--- a/tests/StorageManagerTestCase.py
+++ b/tests/StorageManagerTestCase.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+from dotenv import load_dotenv
+from fGOaria.classes.client_provider import ProviderClient
+from fGOaria.classes.storage_manager import StorageManager
+from fGOaria.classes.storage_provider import StorageProvider
+
+class StorageClientTestCase(unittest.TestCase):
+    def setUp(self):
+        load_dotenv()
+        self.password_default = os.getenv('ARIA_CONNECTION_PASSWORD')
+        self.email_default = os.getenv('ARIA_CONNECTION_USERNAME')
+        self.storage_manager = StorageManager(None, '1', 'proposal')
+        self.test_provider = "OneDataClient"
+
+    def testGetProviders(self):
+        """Test retrieving storage providers"""
+        self.assertIsNotNone(self.storage_manager.providers, "Providers not set")
+        self.assertIsInstance(self.storage_manager.providers, dict, "GetProviders did not return a dict")
+        self.assertIsNotNone(self.storage_manager.providers.get(self.test_provider), self.test_provider+" not found")
+        self.assertIsInstance(self.storage_manager.providers.get(self.test_provider), StorageProvider, "StorageProvider obj not found")
+
+    def testOption(self):
+        print("test opt", self.storage_manager.providers.keys())
+        clients = list(self.storage_manager.providers.keys())
+        self.assertEqual(clients[0], "OneDataClient", "Couldn't find OneDataClient")
+
+    def testSelect(self):
+        client = self.storage_manager.select('OneDataClient')
+        self.assertIsInstance(client, ProviderClient, "Select did not return a ProviderClient")
+
+    def testUpload(self):
+        """@todo"""
+        # self.storage_manager.select('OneDataClient').upload('thing')
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implementing initial structure for storage brokering functionality. A lot still to be fleshed out in future updates

## Discussion

- Refactored the client structure to allow for reuse in different storage provider clients, etc
   - The original `AriaClient` class is now called `ARIA` and has been deprecated
   - `APIClient` is now an abstract base class, with abstract properties `base_url` and `headers` to be implemented or updated by child classes
   - A new abstract class `AriaClient` (inheriting `APIClient`) has been added to contain ARIA-specific client functionality in the class hierarchy
   - The original `ClientOauth` class is now called `AriaOauthClient` (since it inherits the `AriaClient`)
- Added new class `StorageManager` that functions as the central point of access for retrieving and selecting options
- Added new model class `StorageProvider` that describes the structure of a storage provider
- Added new stub class `StorageClient` (inheriting the refactored `AriaClient`) to interface with ARIA's storage API
   - Currently returns the environment variables for OneData rather than querying ARIA's API
- Added new abstract class `ProviderClient` (inheriting the refactored `APIClient`) that describes the structure of a provider client, including upload/download, etc abstract functions
- Added new stub `OneDataClient` class (inheriting the `ProviderClient`) that contains OneData-specific download/upload implementation
- Removed test files from the .gitignore and added unit tests for the `StorageManager` class

## Impact

LIHC Even renaming the old `AriaClient` class shouldn't affect anyone, as I have included it as an alias for the new `ARIA` manager class in the export file

## QA

I haven't yet tested using any actual OneData endpoints, but if you have them, you will need to add the following to your .env file to test

```
ONEDATA_TOKEN=
ONEDATA_HOST_ENDPOINT=https://plg-cyfronet-02.datahub.egi.eu
ONEDATA_SPACE_ID=
ONEDATA_OPTIONS=
```

For now, just use the provided unit tests

---

Closes HMS-5645,
Closes HMS-5646