### PR TITLE
Add Credentials class and prepare for upload/download changes

### DIFF
--- a/fGOaria/classes/client_provider.py
+++ b/fGOaria/classes/client_provider.py
@@ -14,14 +14,22 @@ class ProviderClient(APIClient, ABC):
 
     @property
     def _token(self) -> Token:
-        return Token(self._provider.credentials)
+        return self._provider.credentials.token
+
+    @property
+    def provider_host(self) -> str:
+        return self._provider.credentials.host_endpoint
 
     @property
     def file_id(self) -> str:
         return self._file_id
 
-    @file_id.setter
-    def file_id(self, file_id: str):
+    @property
+    def _file_id(self) -> str:
+        return self._file_id
+
+    @_file_id.setter
+    def _file_id(self, file_id: str):
         self._file_id = file_id
 
     @abstractmethod
@@ -52,8 +60,7 @@ class OneDataClient(ProviderClient):
 
     def __init__(self, provider: StorageProvider):
         super().__init__(provider)
-        self.provider_host = provider.credentials.get('host_endpoint')
-        self.space_id = provider.credentials.get('space_id')
+        self.space_id = provider.credentials.options.get('space_id')
 
     @property
     def base_url(self) -> str:
@@ -72,7 +79,7 @@ class OneDataClient(ProviderClient):
         print(f"Push: {response.status_code} - {response.text}")
         # TODO: handle bad status codes
         if response.status_code in range(200, 300):
-            self.file_id = response.file_id
+            self._file_id = response.file_id
         return response
 
     def download(self, file_id) -> object:

--- a/fGOaria/classes/client_provider.py
+++ b/fGOaria/classes/client_provider.py
@@ -25,7 +25,7 @@ class ProviderClient(APIClient, ABC):
         return self._file_id
 
     @property
-    def _file_id(self) -> str:
+    def _file_id(self) -> str: # this may seem redundant, but is required for a private setter
         return self._file_id
 
     @_file_id.setter

--- a/fGOaria/classes/client_storage.py
+++ b/fGOaria/classes/client_storage.py
@@ -1,6 +1,5 @@
 import os
 from dotenv import load_dotenv
-from typing import Dict
 from fGOaria.classes.aria_client import AriaClient
 from fGOaria.classes.credentials import Credentials
 from fGOaria.classes.storage_provider import StorageProvider
@@ -21,7 +20,7 @@ class StorageClient(AriaClient):
         self.id = entity_id
         self.type = entity_type
 
-    def get_provider_options(self) -> Dict[str, StorageProvider]:
+    def get_provider_options(self) -> dict[str, StorageProvider]:
         """
         Retrieve all available storage provider options
         @todo use ARIA storageProviders query
@@ -43,7 +42,7 @@ class StorageClient(AriaClient):
         Retrieve the token for a specific provider
         @todo use ARIA getStorageTokens mutation
         """
-        print(f'Pulling token')
+        print(f'Pulling token for provider {provider_id}')
         return Token({
             'access_token': os.getenv("ONEDATA_ACCESS_TOKEN"),
             'expires_in': None,

--- a/fGOaria/classes/client_storage.py
+++ b/fGOaria/classes/client_storage.py
@@ -2,6 +2,7 @@ import os
 from dotenv import load_dotenv
 from typing import Dict
 from fGOaria.classes.aria_client import AriaClient
+from fGOaria.classes.credentials import Credentials
 from fGOaria.classes.storage_provider import StorageProvider
 from fGOaria.classes.token import Token
 # from fGOaria.utils.queries import GET_STORAGE_PROVIDERS, FETCH_STORAGE_TOKENS, CHECK_STORAGE_VALIDITY
@@ -30,11 +31,11 @@ class StorageClient(AriaClient):
             provider_id='1',
             name="OneData",
             description="High-performance data management solution",
-            credentials={
-                'host_endpoint': os.getenv("ONEDATA_HOST_ENDPOINT"),
-                'token': self.get_provider_token('1'),
-                'space_id': os.getenv("ONEDATA_SPACE_ID"),
-            }
+            credentials=Credentials(
+                host_endpoint=os.getenv("ONEDATA_HOST_ENDPOINT"),
+                token=self.get_provider_token('1'),
+                options={'space_id': os.getenv("ONEDATA_SPACE_ID")}
+            )
         )}
 
     def get_provider_token(self, provider_id: str) -> Token or None:

--- a/fGOaria/classes/credentials.py
+++ b/fGOaria/classes/credentials.py
@@ -1,0 +1,27 @@
+from fGOaria.classes.token import Token
+
+class Credentials:
+    """
+    Represents the credentials required to connect to a client
+    """
+
+    def __init__(self, host_endpoint: str, token: Token, options: dict):
+        self._host_endpoint = host_endpoint
+        self._token = token
+        self._options = options
+
+    @property
+    def host_endpoint(self) -> str:
+        return self._host_endpoint
+
+    @property
+    def token(self) -> Token:
+        return self._token
+
+    @property
+    def options(self) -> dict:
+        return self._options
+
+    @options.setter
+    def options(self, options: dict):
+        self._options = options

--- a/fGOaria/classes/storage_provider.py
+++ b/fGOaria/classes/storage_provider.py
@@ -1,5 +1,11 @@
+from fGOaria.classes.credentials import Credentials
+
 class StorageProvider():
-    def __init__(self, provider_id: str, name: str, description: str, credentials: dict):
+    """
+    Represents a storage provider option
+    """
+
+    def __init__(self, provider_id: str, name: str, description: str, credentials: Credentials = None):
         self._id = provider_id
         self._name = name
         self._description = description
@@ -8,39 +14,24 @@ class StorageProvider():
     @property
     def provider_id(self) -> str:
         """Getter for the Provider ID."""
-        return self._provider_id
-
-    @provider_id.setter
-    def provider_id(self, value):
-        """Setter for the Provider ID."""
-        self._provider_id = value
+        return self._id
 
     @property
     def name(self) -> str:
         """Getter for the name of the provider."""
         return self._name
 
-    @name.setter
-    def name(self, value):
-        """Setter for the name of the provider."""
-        self._name = value
-
     @property
     def description(self) -> str:
         """Getter for the description of the provider."""
         return self._description
 
-    @description.setter
-    def description(self, value):
-        """Setter for the description of the provider."""
-        self._description = value
-
     @property
-    def credentials(self) -> dict:
+    def credentials(self) -> Credentials:
         """Get credentials from my provider."""
         return self._credentials
 
     @credentials.setter
-    def credentials(self, value):
+    def credentials(self, credentials: Credentials):
         """Setter for the description of the provider."""
-        self._credentials = value
+        self._credentials = credentials

--- a/tests/StorageManagerTestCase.py
+++ b/tests/StorageManagerTestCase.py
@@ -17,21 +17,37 @@ class StorageClientTestCase(unittest.TestCase):
         """Test retrieving storage providers"""
         self.assertIsNotNone(self.storage_manager.providers, "Providers not set")
         self.assertIsInstance(self.storage_manager.providers, dict, "GetProviders did not return a dict")
-        self.assertIsNotNone(self.storage_manager.providers.get(self.test_provider), self.test_provider+" not found")
+        self.assertIsNotNone(self.storage_manager.providers.get(self.test_provider), f"{self.test_provider} not found")
         self.assertIsInstance(self.storage_manager.providers.get(self.test_provider), StorageProvider, "StorageProvider obj not found")
 
     def testOption(self):
         print("test opt", self.storage_manager.providers.keys())
         clients = list(self.storage_manager.providers.keys())
-        self.assertEqual(clients[0], "OneDataClient", "Couldn't find OneDataClient")
+        self.assertEqual(clients[0], self.test_provider, f"Couldn't find {self.test_provider}")
 
     def testSelect(self):
-        client = self.storage_manager.select('OneDataClient')
+        client = self.storage_manager.select(self.test_provider)
         self.assertIsInstance(client, ProviderClient, "Select did not return a ProviderClient")
+        self.assertIs(client.__class__.__name__, self.test_provider, f"Select did not return a {self.test_provider}")
 
-    def testUpload(self):
+    def testUploadFile(self):
         """@todo"""
         # self.storage_manager.select('OneDataClient').upload('thing')
+        pass
+
+    def testFindLocationFile(self):
+        """@todo"""
+        # self.file_id or self.location = self.storage_manager.select('OneDataClient').locate('thing')
+        pass
+
+    def testDownloadFile(self):
+        """@todo"""
+        # self.storage_manager.select('OneDataClient').download('thing', self.file_id)
+        pass
+
+    def testDeleteFile(self):
+        """@todo"""
+        # self.storage_manager.select('OneDataClient').delete('thing', self.file_id)
         pass
 
 


### PR DESCRIPTION
I noticed that the Token was not being set correctly in the `ProviderClient`, and it would be cleaner and simpler to pass the provider credentials to the client if a credentials structure was enforced, so I've added a new `Credentials` class that passes the token data and also allows custom options depending on the provider (e.g. `space_id` for OneData)

Also added some todos to the test, for upload/download etc, and removed some unnecessary property setters