### PR TITLE
Add storage management to the demo CLI app

### DIFF
--- a/fGOaria/classes/aria_manager.py
+++ b/fGOaria/classes/aria_manager.py
@@ -1,3 +1,4 @@
+from fGOaria.classes.storage_manager import StorageManager
 from fGOaria.classes.oauth import OAuth
 from fGOaria.classes.data_manager import DataManager
 from fGOaria.classes.cli_techeval import TechEvalCLI
@@ -30,8 +31,10 @@ class ARIA:
     
     def new_cli_data_manager(self, id, type, populate=False) :
         return (DataManagerCLI(self.token, id, type, populate))
-    
-    
+
+    def new_storage_manager(self, id, type):
+        return (StorageManager(self.token, id, type))
+
     def new_cli_tech_eval(self) :
         return (TechEvalCLI(self.token))
 

--- a/fGOaria/commands/cli.py
+++ b/fGOaria/commands/cli.py
@@ -4,6 +4,7 @@ warnings.filterwarnings("ignore")
 from fGOaria.utils.imports_config import click
 from fGOaria.commands.login import login
 from fGOaria.commands import data
+from fGOaria.commands import storage
 from fGOaria.commands import visit
 
 
@@ -25,6 +26,7 @@ cli.add_command(data.create_field, 'create-field')
 cli.add_command(data.list_buckets, 'list-buckets')
 cli.add_command(data.list_records, 'list-records')
 cli.add_command(data.list_fields, 'list-fields')
+cli.add_command(storage.provision_storage_option, 'manage-storage')
 cli.add_command(visit.tech_eval, 'tech-eval')
 
 if __name__ == '__main__':

--- a/fGOaria/commands/storage.py
+++ b/fGOaria/commands/storage.py
@@ -1,0 +1,57 @@
+from types import MappingProxyType
+
+from fGOaria.classes.client_provider import ProviderClient
+from fGOaria.utils import utility_functions as utils
+from fGOaria.utils.imports_config import click
+from fGOaria.classes.aria_manager import ARIA
+
+ACTION_UPLOAD = ProviderClient.upload.__name__
+ACTION_DOWNLOAD = ProviderClient.download.__name__
+ACTION_LOCATE = ProviderClient.locate.__name__
+ACTION_DELETE = ProviderClient.delete.__name__
+
+PROVIDER_ACTIONS = MappingProxyType({
+    0: ACTION_UPLOAD,
+    1: ACTION_DOWNLOAD,
+    2: ACTION_LOCATE,
+    3: ACTION_DELETE
+})
+
+# @click.command()
+# def view_storage_options():
+#     """Display the available storage options"""
+#     cli = ARIA()
+#     entity_details = utils.get_entity()
+#     manager = cli.new_storage_manager(entity_details.get('id'), entity_details.get('type'))
+#     print(manager.providers)
+
+@click.command()
+def provision_storage_option():
+    """Select a storage provider, provision storage and perform actions within the provider's data space"""
+    cli = ARIA()
+    entity_details = utils.get_entity()
+    entity_type = entity_details.get('type')
+    entity_id = entity_details.get('id')
+    manager = cli.new_storage_manager(str(entity_id), entity_type)
+
+    utils.print_with_spaces(f"Finding available storage options in ARIA for {entity_type} ID {entity_id}...")
+    selected = utils.command_with_options("Select a storage option", manager.providers)
+    manager.select(selected)
+
+    utils.print_with_spaces(f"Provisioning storage from {selected}...")
+    manager.provision()
+    print("Successfully provisioned")
+
+    file_id = None
+    while True:
+        if file_id is not None:
+            utils.print_with_spaces(f"Current File ID: {file_id}\n\n")
+
+        action = utils.command_with_options(f"Which action do you want to perform?",
+                                            list(PROVIDER_ACTIONS.values()))
+
+        print()
+        if (action == ACTION_UPLOAD):
+            file_location = click.prompt('File name and location', type=str)
+            file_id = manager.client.upload(file_location)
+            utils.print_with_spaces(f"Successfully uploaded {file_location} to {selected}")


### PR DESCRIPTION
Added a CLI command `manage_storage` to the demo app which walks the use through the storage brokering steps, and then allows them to perform actions on the storage provider (currently only upload)